### PR TITLE
add random name

### DIFF
--- a/potemkin/utilities.py
+++ b/potemkin/utilities.py
@@ -1,0 +1,10 @@
+""" Utilities not specific to an aws Service """
+from random import randint
+
+
+def random_name(name, digits=10):
+    """ Create a name with a random digits string at the end. Defaults to 10 digits """
+
+    range_low = 10**(digits - 1)
+    range_high = (10**digits) - 1
+    return f'{name}{randint(range_low, range_high)}'

--- a/test/unit/utilities_test.py
+++ b/test/unit/utilities_test.py
@@ -1,0 +1,21 @@
+from potemkin import utilities
+
+
+def test_utilities_default():
+    """ test not specifying digits returns name with 10 digits appended """
+    name = 'testname'
+    full_name = utilities.random_name(name)
+
+    assert len(full_name) == len(name) + 10
+    assert isinstance((int(full_name[len(name):])), int)
+
+
+def test_utilities_digits():
+    """ test specifying digits returns name with correct number of digits """
+    name = 'testname'
+    digits = 3
+
+    full_name = utilities.random_name(name, digits=digits)
+
+    assert len(full_name) == len(name) + digits
+    assert isinstance((int(full_name[len(name):])), int)


### PR DESCRIPTION
When doing the testing of different parallel strategies, I ran into some stack failures since bucket names existed. I created a function like this to add random  numbers to a name.